### PR TITLE
feat: list views and tweet

### DIFF
--- a/libs/notion/log.ts
+++ b/libs/notion/log.ts
@@ -1,11 +1,7 @@
-import { Client } from "@notionhq/client";
 import {
-  Device,
-  Diet,
   LogOutPut,
   LogProperty,
   MonthlyRecord,
-  Morning,
   MorningActivity,
 } from "./types";
 import { digDeviceData, digDietData, digMorningData, notion } from "./utils";
@@ -77,6 +73,7 @@ const createLogOutput = (
 
   //   結合する
   const logOutput: LogOutPut = {
+    uuid: logProps.uuid.formula.string,
     title: logProps.title.title[0].plain_text,
     date: logProps.date.date.start,
     mornings,
@@ -90,7 +87,7 @@ const createLogOutput = (
 };
 
 export const getAllLogsDate = async () => {
-  const logs = await getLogListFromNow();
+  const logs = await getLogListFromNow(false);
   const dates = logs.tableData.map((log) => log.date);
   return dates;
 };

--- a/libs/notion/logList.ts
+++ b/libs/notion/logList.ts
@@ -2,27 +2,14 @@ import { LogListType } from "@/pages";
 import { LogListPropertyForGitLikeCalender, LogTableProperty } from "./types";
 import { notion } from "./utils";
 
-export const getLogListFromNow = async (): Promise<LogListOutPut> => {
+export const getLogListFromNow = async (
+  onlyPubLish: boolean
+): Promise<LogListOutPut> => {
+  const conditions = switchSearchCondition(onlyPubLish);
   const { results } = await notion.databases.query({
     database_id: "8af74dfac9a0482bab353741bb355971",
-    filter: {
-      and: [
-        {
-          property: "published",
-          formula: {
-            checkbox: {
-              equals: true,
-            },
-          },
-        },
-        {
-          property: "date",
-          date: {
-            past_year: {},
-          },
-        },
-      ],
-    },
+    filter: conditions,
+
     sorts: [
       {
         property: "date",
@@ -75,7 +62,38 @@ const destructureForTable = (
       date: log.properties.date.date.start,
       title: log.properties.title.title[0].plain_text,
       tweetUrl: log.properties.tweetUrl.url,
+      published: log.properties.published.formula.boolean,
     };
   });
   return tgt;
+};
+
+const switchSearchCondition = (onlyPubLish: boolean) => {
+  if (onlyPubLish) {
+    return {
+      and: [
+        {
+          property: "published",
+          formula: {
+            checkbox: {
+              equals: true,
+            },
+          },
+        },
+        {
+          property: "date",
+          date: {
+            past_year: {},
+          },
+        },
+      ],
+    };
+  } else {
+    return {
+      property: "date",
+      date: {
+        past_year: {},
+      },
+    };
+  }
 };

--- a/libs/notion/types.ts
+++ b/libs/notion/types.ts
@@ -1,8 +1,4 @@
 // notion built-in types
-
-import { type } from "os";
-import { typeOf } from "react-is";
-
 // ----------------------------------------
 export type FileProperty = {
   files: [{ file: { url: string } }];
@@ -64,6 +60,7 @@ export type Device = {
 // notion API response types
 export type LogProperty = {
   // TODO ここで、掘るよ
+  uuid: FormulaStringProperty;
   title: TitleProperty;
   date: DateProperty;
   morningImage: FileProperty;
@@ -91,6 +88,7 @@ export type MonthlyRecord = {
 // ----------------------------------------
 // notion API response in the end
 export type LogOutPut = {
+  uuid: string;
   title: string;
   date: string;
   mornings: Morning;
@@ -107,6 +105,7 @@ type LogListProperty = {
   title: TitleProperty;
   tweetUrl: UrlProperty;
   date: DateProperty;
+  published: FormulaBooleanProperty;
 };
 export type LogListPropertyForGitLikeCalender = [
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-github-contribution-calendar": "^2.2.0",
+        "twitter-api-sdk": "^1.2.1",
+        "twitter-api-v2": "^1.14.2",
         "typescript": "5.0.4"
       }
     },
@@ -1028,6 +1030,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/acorn": {
@@ -2166,6 +2179,14 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/execa": {
@@ -4327,6 +4348,23 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/twitter-api-sdk": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/twitter-api-sdk/-/twitter-api-sdk-1.2.1.tgz",
+      "integrity": "sha512-tNQ6DGYucFk94JlnUMsHCkHg5o1wnCdHh71Y2ukygNVssOdD1gNVjOpaojJrdwbEAhoZvcWdGHerCa55F8HKxQ==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/twitter-api-v2": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.14.2.tgz",
+      "integrity": "sha512-389e/rWaN8zWkmD5z2IpKVb5+ojPxVtrexQoGBI1Xfib1mE/9M7k7zbnZ3Q/WLwthwcWkQIlB25ecT64AL8LvQ=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-github-contribution-calendar": "^2.2.0",
+    "twitter-api-sdk": "^1.2.1",
+    "twitter-api-v2": "^1.14.2",
     "typescript": "5.0.4"
   }
 }

--- a/src/components/logListTable.tsx
+++ b/src/components/logListTable.tsx
@@ -10,40 +10,117 @@ import { LogTableProperty } from "../../libs/notion/types";
 import { LogListType } from "@/pages";
 import Link from "next/link";
 import Router from "next/router";
-import { Chip } from "@mui/material";
+import { Checkbox, Chip, Modal } from "@mui/material";
+import { useState } from "react";
+import { callExecTweetApi } from "@/pages/api/tweet/execTweet";
 
-export default function DenseTable({ logList }: { logList: LogListType[] }) {
+export default function LogTable({
+  logList,
+  isAdmin,
+}: {
+  logList: LogListType[];
+  isAdmin: boolean;
+}) {
   const onClickDateHandler = (isoString: string) => {
     Router.push(`/logs/${isoString}`);
   };
+  const checkBoxLabel = { inputProps: { "aria-label": "Checkbox demo" } };
+
+  const [tweetConfirmModalOpen, setTweetConfirmModalOpen] = useState(false);
+  const [tgtTweet, setTgtTweet] = useState<LogListType>();
+  const onClickTweetHandler = (log: LogListType) => {
+    setTweetConfirmModalOpen(true);
+    setTgtTweet(log);
+  };
+
   return (
-    <TableContainer component={Paper}>
-      <Table sx={{ minWidth: 300 }} size="small" aria-label="a dense table">
-        <TableHead>
-          <TableRow>
-            <TableCell>タイトル</TableCell>
-            <TableCell align="right">日付</TableCell>
-            <TableCell align="right">twitter URL</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {logList.map((log) => (
-            <TableRow
-              key={log.uuid}
-              sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
-            >
-              <TableCell align="right">
-                <Chip
-                  label={log.title}
-                  onClick={() => onClickDateHandler(log.date)}
-                />
-              </TableCell>
-              <TableCell align="right">{log.date}</TableCell>
-              <TableCell align="right">{log.tweetUrl}</TableCell>
+    <>
+      <TableContainer component={Paper}>
+        <Table sx={{ minWidth: 300 }} size="small" aria-label="a dense table">
+          <TableHead>
+            <TableRow>
+              {isAdmin && <TableCell>Published?</TableCell>}
+              {isAdmin && <TableCell>tweeted</TableCell>}
+              <TableCell>タイトル</TableCell>
+              <TableCell align="right">日付</TableCell>
+              <TableCell align="right">twitter URL</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </TableContainer>
+          </TableHead>
+          <TableBody>
+            {logList.map((log) => (
+              <TableRow
+                key={log.uuid}
+                sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
+              >
+                {isAdmin && (
+                  <TableCell component="th" scope="row">
+                    <Checkbox
+                      {...checkBoxLabel}
+                      checked={log.published}
+                      aria-label="published"
+                    />
+                  </TableCell>
+                )}
+                {isAdmin && (
+                  <TableCell component="th" scope="row">
+                    <Checkbox
+                      onChange={() => onClickTweetHandler(log)}
+                      {...checkBoxLabel}
+                      checked={!!log.tweetUrl}
+                      aria-label="tweeted"
+                    />
+                  </TableCell>
+                )}
+                <TableCell align="right">
+                  <Chip
+                    label={log.title}
+                    onClick={() => onClickDateHandler(log.date)}
+                  />
+                </TableCell>
+                <TableCell align="right">{log.date}</TableCell>
+                <TableCell align="right">{log.tweetUrl}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      {tgtTweet && (
+        <TweetConfirmModal
+          log={tgtTweet}
+          open={tweetConfirmModalOpen}
+          handleClose={() => setTweetConfirmModalOpen(false)}
+        />
+      )}
+    </>
   );
 }
+
+const TweetConfirmModal = ({
+  log,
+  open,
+  handleClose,
+}: {
+  log: LogListType;
+  open: boolean;
+  handleClose: () => void;
+}) => {
+  const onClickTweetHandler = async () => {
+    await callExecTweetApi(log.date);
+  };
+  return (
+    <Modal
+      aria-labelledby="transition-modal-title"
+      aria-describedby="transition-modal-description"
+      open={open}
+      onClose={handleClose}
+      closeAfterTransition
+    >
+      <div>
+        <h1>ツイートしますか？</h1>
+        <p>{log.date}</p>
+        <p>{log.title}</p>
+        <button onClick={onClickTweetHandler}>ツイートする</button>
+      </div>
+    </Modal>
+  );
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(req: NextRequest): NextResponse | Response {
+  // Check if the path starts with /admin
+  if (req.nextUrl.pathname.startsWith("/admin")) {
+    const basicAuth = req.headers.get("authorization");
+
+    if (basicAuth) {
+      const auth = basicAuth.split(" ")[1];
+      const [user, pwd] = Buffer.from(auth, "base64").toString().split(":");
+      if (
+        user === process.env.NEXT_PUBLIC_USER &&
+        pwd === process.env.NEXT_PUBLIC_PASS
+      ) {
+        return NextResponse.next();
+      }
+    }
+
+    return new Response("Auth required", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": 'Basic realm="Secure Area"',
+      },
+    });
+  }
+
+  // If the path is not /admin, proceed without applying the middleware
+  return NextResponse.next();
+}

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from "react";
+import { LogListType } from "..";
+import LogTable from "@/components/logListTable";
+import axios from "axios";
+
+const TweetAdmin = () => {
+  const [logData, setLogData] = useState<LogListType[]>();
+  useEffect(() => {
+    (async () => {
+      const { data } = await axios.get(
+        "http://localhost:3000/api/log/list?onlyPublished=false"
+      );
+      setLogData(data.tableData);
+    })();
+  }, []);
+
+  return logData && <LogTable logList={logData} isAdmin={true} />;
+};
+
+export default TweetAdmin;

--- a/src/pages/api/log/list.ts
+++ b/src/pages/api/log/list.ts
@@ -2,7 +2,8 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { getLogListFromNow } from "../../../../libs/notion/logList";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  const data = await getLogListFromNow();
+  const onlyPubLish = req.query.onlyPubLish === "true" ? true : false;
+  const data = await getLogListFromNow(onlyPubLish);
   res.status(200).json(data);
 };
 

--- a/src/pages/api/tweet/_generateTweet.ts
+++ b/src/pages/api/tweet/_generateTweet.ts
@@ -1,0 +1,35 @@
+import { LogOutPut } from "../../../../libs/notion/types";
+import { convertToJST } from "./timeLib";
+
+export const generateTweetData = (log: LogOutPut) => {
+  /*
+2023/05/07 今日の記録
+
+起床時間 10:00 目標より20分早い
+スクリーンタイム 目標より15分少ない
+食事: 3000kcal 目標より500少ない
+
+下記URLでタスク以外の３つの行動が事実である証明をしています。
+
+明日も頑張ります
+  */
+  const str = `
+${convertToJST(log.date, "A")} 今日の記録
+
+起床時間 ${convertToJST(log.mornings.morningActivityTime, "B")} 目標より${
+    log.mornings.morningActivityGapMinutes
+  }分${log.mornings.morningActivityGapMinutes > 0 ? "早い" : "遅い"}
+スクリーンタイム ${log.device.todayScreenTime} 目標より${
+    log.device.screenTimeGapMinutes
+  }分${log.device.screenTimeGapMinutes > 0 ? "少ない" : "多い"}
+食事: ${log.diet.todayCalorie}kcal 目標より${log.diet.todayCalorieGap}kcal${
+    log.diet.todayCalorieGap > 0 ? "少ない" : "多い"
+  }
+
+下記URLでタスク以外の３つの行動が事実である証明をしています。
+http://loccalhost:3000/log/${log.date}
+
+明日も頑張ります
+`;
+  return str;
+};

--- a/src/pages/api/tweet/execTweet.ts
+++ b/src/pages/api/tweet/execTweet.ts
@@ -1,0 +1,86 @@
+import { LogListType } from "@/pages";
+import axios from "axios";
+import { NextApiRequest, NextApiResponse } from "next";
+import { notion } from "../../../../libs/notion/utils";
+import { LogOutPut } from "../../../../libs/notion/types";
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const tgtDate = req.query.date as string;
+
+  // headerのauthを検証する
+  authUser(req, res);
+  const { data } = (await axios.get(
+    `http://localhost:3000/api/log?date=${tgtDate}`
+  )) as { data: LogOutPut };
+  const log = data;
+  // publishedがtrue && tweetUrlが空であるかを確認する
+  const isValidLog = await validateLog(log);
+  if (!isValidLog) {
+    // 無効ならメッセージ付きで500エラーを出す
+    res.status(500).json({ message: "Invalid log" });
+    return;
+  }
+
+  // 無効でなければ、tweetを実行する
+
+  // ここでtwwet用APIを実行する
+
+  const tweetId = await axios.post(
+    "http://localhost:3000/api/tweet/postTweet",
+    {
+      log,
+    }
+  );
+  //   TODO: call lambda function
+
+  const tweetUrl = `https://twitter.com/intern_ukaruzo/status/${tweetId.data}`;
+  await writeTweetUrl(log, tweetUrl);
+  res.status(200).json({ message: "tweet success" });
+};
+
+const authUser = (req: NextApiRequest, res: NextApiResponse) => {
+  const isAuth =
+    req.headers.authorization ==
+    `Bearer ${process.env.NEXT_PUBLIC_TWEET_AUTH_TOKEN}`;
+  // if (!isAuth) {
+  //   res.status(401).json({ message: "Unauthorized" });
+  //   return;
+  // }
+};
+
+const validateLog = async (log: LogListType) => {
+  //   日付に一致するページを"佑弥管理DB"から取得する
+
+  // publishedがtrue && tweetUrlが空であるかを確認する
+  const isPublished = log.published === true;
+  const isTweetUrlEmpty = log.tweetUrl == null || log.tweetUrl === "";
+  const isValid = isPublished && isTweetUrlEmpty;
+  return isValid;
+};
+
+const writeTweetUrl = async (log: LogListType, tweetUrl: string) => {
+  //   "佑弥管理DB"の該当ページのtweetUrlに値を書き込む
+  await notion.pages.update({
+    page_id: log.uuid,
+    properties: {
+      tweetUrl: {
+        url: tweetUrl,
+      },
+    },
+  });
+};
+
+export const callExecTweetApi = async (date: string) => {
+  // heaeder に Authorization をつける
+  const axiosBase = axios.create({
+    headers: {
+      Authorization: `Bearer ${process.env.NEXT_PUBLIC_TWEET_AUTH_TOKEN}`,
+    },
+  });
+  const res = await axiosBase.get(
+    `http://localhost:3000/api/tweet/execTweet?date=${date}`
+  );
+  return res.data;
+};
+
+export default handler;

--- a/src/pages/api/tweet/postTweet.ts
+++ b/src/pages/api/tweet/postTweet.ts
@@ -1,0 +1,27 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+import { generateTweetData } from "./_generateTweet";
+import { LogOutPut } from "../../../../libs/notion/types";
+import { TwitterApi } from "twitter-api-v2";
+
+export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  // '/api/log/ISO str' の 'ISO str' を取得する;
+  const log = req.body.log as LogOutPut;
+  const tweetText = generateTweetData(log);
+  const tweetId = await postTweet(tweetText);
+  res.status(200).json(tweetId);
+};
+export default handler;
+
+type TweetId = string;
+const postTweet = async (tweetText: string): Promise<TweetId> => {
+  const client = new TwitterApi({
+    appKey: process.env.NEXT_PUBLIC_APP_KEY as string,
+    appSecret: process.env.NEXT_PUBLIC_APP_SECRET as string,
+    accessToken: process.env.NEXT_PUBLIC_ACESS_TOKEN as string,
+    accessSecret: process.env.NEXT_PUBLIC_ACESS_TOKEN_SECRET as string,
+  });
+  const { data } = await client.v2.tweet(tweetText);
+  const tweetId = data.id;
+  return tweetId;
+};

--- a/src/pages/api/tweet/timeLib.ts
+++ b/src/pages/api/tweet/timeLib.ts
@@ -1,0 +1,18 @@
+export const convertToJST = (
+  dateTimeString: string,
+  formatType: "A" | "B"
+): string => {
+  const date = new Date(dateTimeString);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+
+  if (formatType === "A") {
+    return `${year}年${month}月${day}日`;
+  } else {
+    return `${month}月${day}日${hours}時${minutes}分`;
+  }
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,27 +1,14 @@
-import Router from "next/router";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Calender from "react-github-contribution-calendar";
-import axios from "axios";
-import {
-  LogListPropertyForGitLikeCalender,
-  LogTableProperty,
-} from "../../libs/notion/types";
-import DenseTable from "@/components/logListTable";
+import LogTable from "@/components/logListTable";
 import { LogListOutPut, getLogListFromNow } from "../../libs/notion/logList";
 import { GetStaticProps } from "next";
-
-export type LogListType = {
-  uuid: string;
-  date: string;
-  title: string;
-  tweetUrl: string;
-};
 
 export const getStaticProps: GetStaticProps = async () => {
   // const { data }: { data: LogListOutPut } = await axios.get(
   //   "http://localhost:3000/api/log/list"
   // );
-  const data = await getLogListFromNow();
+  const data = await getLogListFromNow(false);
 
   if (!data) return { notFound: true };
 
@@ -37,40 +24,42 @@ export const getStaticProps: GetStaticProps = async () => {
 };
 
 const DashBoard = ({ calenderData, tableData }: LogListOutPut) => {
-  const [values, setValues] = useState<{ [date: string]: number }>(
-    calenderData
-  );
-  const [logList, setLogList] = useState<LogListType[]>(tableData);
-
   const until = new Date().toISOString().split("T")[0];
-
-  const weekLabelAttributes = {
-    fill: "#21ba29",
-    fontSize: "11px",
-  };
-  const monthLabelAttributes = {
-    fill: "#d22020",
-    fontSize: "13px",
-  };
-  const panelAttributes = {
-    strokeWidth: 0.5,
-    stroke: "#49259c",
-  };
+  const { weekLabel, monthLabel, panel } = LabelDesigns;
 
   return (
     <div>
-      {values && (
-        <Calender
-          values={values}
-          until={until}
-          weekLabelAttributes={weekLabelAttributes}
-          monthLabelAttributes={monthLabelAttributes}
-          panelAttributes={panelAttributes}
-        />
-      )}
-      <div>{logList && <DenseTable logList={logList} />}</div>
+      <Calender
+        values={calenderData}
+        until={until}
+        weekLabelAttributes={weekLabel}
+        monthLabelAttributes={monthLabel}
+        panelAttributes={panel}
+      />
+      <LogTable logList={tableData} isAdmin={false} />
     </div>
   );
 };
+const LabelDesigns = {
+  weekLabel: {
+    fill: "#21ba29",
+    fontSize: "11px",
+  },
+  monthLabel: {
+    fill: "#d22020",
+    fontSize: "13px",
+  },
+  panel: {
+    strokeWidth: 0.5,
+    stroke: "#49259c",
+  },
+};
 
+export type LogListType = {
+  uuid: string;
+  date: string;
+  title: string;
+  tweetUrl: string;
+  published: boolean;
+};
 export default DashBoard;


### PR DESCRIPTION
一覧表示画面と、admin管理画面を作成しました。
twitter APIを叩いてツイートする機能も作成しました。

twitter関連の機能は3階層に関心を分離しました。全てnext.jsのAPIとして作成し、将来的なLambdaでのバッジ処理に備えています。

1. ツイートのトリガーAPI
2. ツイート関連のハンドリングAPI
3. ツイートをするだけのAPI

まず、トリガー部分
- 管理画面から指定の日付のログを選択し、モーダルにて同意することでトリガーできます。
- もしくはLambda(現段階では未実装)によるバッチ処理でAPIをコールことでトリガーします。

ツイート関連のハンドリング部分
- APIのリクエストボディには、日付が渡ってきます
- 次に日付に一致するログをnotionAPIで取得します
- データをもとにツイート用の文章の定形文を生成します
- ツイートするだけどAPIをここで呼び出します。bodyには生成した文章を載せます
- 投稿が完了したら、投稿されたtweetのIDが投稿専用APIから返却されるので、notionのログのtweetUrlカラムにAPIでputして書き込みます